### PR TITLE
Issue/3/implement help function

### DIFF
--- a/mycommands/mycommands.py
+++ b/mycommands/mycommands.py
@@ -128,11 +128,9 @@ class ListAll(MyCommand):
             # Command classes have names, and maybe aliases.
             for com in filter(None, self.commandDict.values()):
                 addToNameSpace(self.commandNameSpace, com.name, com)
-                try:
+                if hasattr(com, "aliases"):
                     for a in com.aliases:
                         addToNameSpace(self.commandNameSpace, a, com)
-                except:
-                    continue
         # addToNameSpace refuses to put duplicate keys into dictionary.
         except ValueError as e:
             raise e

--- a/mycommands/mycommands.py
+++ b/mycommands/mycommands.py
@@ -102,11 +102,7 @@ class ListAll(MyCommand):
                 assert isinstance(com.name, str), "Command class name is not a string."
                 
                 # Should there be optional aliases, they must be a list of strings.
-                try:
-                    aliases = com.aliases
-                except:
-                    continue
-                else:
+                if hasattr(com, "aliases"):
                     assert (isinstance(com.aliases, list)), "Command aliases is not a list."
                     assert all(isinstance(a, str) for a in com.aliases), "Command alias is not a string."
         except AttributeError:
@@ -114,6 +110,7 @@ class ListAll(MyCommand):
 
     def __buildNamespaces(self):
         def addToNameSpace(d: dict, name: str, inputtedClass: classmethod):
+            # addToNameSpace refuses to put duplicate keys into dictionary.
             if name.lower() in d:
                 raise ValueError(f"Duplicate name or alias: \"{name.lower()}\" already in dictionary.")
             d[name.lower()] = inputtedClass
@@ -131,7 +128,6 @@ class ListAll(MyCommand):
                 if hasattr(com, "aliases"):
                     for a in com.aliases:
                         addToNameSpace(self.commandNameSpace, a, com)
-        # addToNameSpace refuses to put duplicate keys into dictionary.
         except ValueError as e:
             raise e
         except Exception as e:

--- a/mycommands/mycommands.py
+++ b/mycommands/mycommands.py
@@ -109,11 +109,12 @@ class ListAll(MyCommand):
             raise AttributeError("Command classes must have a name.")
 
     def __buildNamespaces(self):
-        def addToNameSpace(d: dict, name: str, inputtedClass: classmethod):
+        def addToNameSpace(d: dict, inputtedName: str, inputtedClass: classmethod):
+            name = inputtedName.lower()
             # addToNameSpace refuses to put duplicate keys into dictionary.
-            if name.lower() in d:
-                raise ValueError(f"Duplicate name or alias: \"{name.lower()}\" already in dictionary.")
-            d[name.lower()] = inputtedClass
+            if name in d:
+                raise ValueError(f"Duplicate name or alias: \"{name}\" already in dictionary.")
+            d[name] = inputtedClass
 
         try:
             # Associates [class].name and [class].aliases with the program or command class in a namespace.
@@ -150,33 +151,35 @@ class ListAll(MyCommand):
             except Exception as e:
                 raise Exception(f"An unexpected error occurred with \"ListAll\": {e}")
 
-    def findProgram(self, searchStr: str) -> classmethod | None:
+    def findProgram(self, inputtedSearchStr: str) -> classmethod | None:
         try:
-            if searchStr.lower() in self.ProgramDict:
-                return self.ProgramDict[searchStr.lower()]
-            elif searchStr.lower() in self.programNameSpace:
-                return self.programNameSpace[searchStr.lower()]
+            searchStr = inputtedSearchStr.lower()
+            if searchStr in self.ProgramDict:
+                return self.ProgramDict[searchStr]
+            elif searchStr in self.programNameSpace:
+                return self.programNameSpace[searchStr]
             else:
                 return None
         except Exception as e:
             raise Exception(f"An unexpected error occurred with ListAll.findProgram(): {e}")
         
-    def findCommand(self, searchStr: str) -> classmethod | None:
+    def findCommand(self, inputtedSearchStr: str) -> classmethod | None:
         try:
-            if searchStr.lower() in self.commandDict:
-                return self.commandDict[searchStr.lower()]
-            elif searchStr.lower() in self.commandNameSpace:
-                return self.commandNameSpace[searchStr.lower()]
+            searchStr = inputtedSearchStr.lower()
+            if searchStr in self.commandDict:
+                return self.commandDict[searchStr]
+            elif searchStr in self.commandNameSpace:
+                return self.commandNameSpace[searchStr]
             else:
                 return None
         except Exception as e:
             raise Exception(f"An unexpected error occured with ListAll.findCommand(): {e}")
     
     def getHelp(self, searchStr: str) -> print:
-        if (prog := self.findProgram(searchStr)) != None:
+        if (prog := self.findProgram(searchStr)):
             prog.help()
             
-        elif (com := self.findCommand(searchStr)) != None:
+        elif (com := self.findCommand(searchStr)):
             com.help()
 
         elif searchStr in ["help", "info"]:

--- a/mycommands/mycommands.py
+++ b/mycommands/mycommands.py
@@ -5,22 +5,21 @@ class MyCommand:
     """A command."""
     def __init__(self):
         self.manual = self.__doc__
-
+    
     def help(self) -> print:
         try:
-            for line in self.manual:
-                print(line)
+            print(self.manual)
         except Exception as e:
-            raise Exception(f"An unexpected error occured with printing help info: {e}")
+            raise Exception(f"An unexpected error occurred with printing help info: {e}")
 
 
 
 class ClearTerminal(MyCommand):
     """Clears the terminal. Works on posix and nt-like systems."""
+    name = "Clear"
+    aliases = ["cls"]
 
     def __init__(self):
-        self.name = "clear"
-
         self.operation = self.ClearTerminal
 
         super().__init__()
@@ -46,9 +45,9 @@ class ClearTerminal(MyCommand):
 class PageBreak(MyCommand):
     """Prints a long line and then moves to the next line of the terminal."""
 
+    name = "PageBreak"
+
     def __init__(self):
-        self.name = "PageBreak"
-        
         self.operation = self.PageBreak
 
         super().__init__()
@@ -65,29 +64,128 @@ class ListAll(MyCommand):
     """Lists all available programs and commands currently available.
     
     Clears the terminal beforehand for legibility."""
-    def __init__(self, programMap: dict, commandMap: dict):
-        self.name = "ListAll"
+    name = "ListAll"
+    aliases = ["list", "ls", "list all"]
+
+    def __init__(self, ProgramDict: dict = {}, commandDict: dict = {}):
+        self.programNameSpace = {}
+        self.commandNameSpace = {}
+
+        def addToNameSpace(d: dict, name: str, inputtedClass = classmethod):
+            d[name.lower()] = inputtedClass
 
         try:
-            self.programMap = dict(programMap)
-            self.commandMap = dict(commandMap)
+            self.ProgramDict = dict(ProgramDict)
+            self.commandDict = dict(commandDict)
         except:
             raise ValueError("ListAll only accepts dict objects.")
+        
+        # Make sure all programs have a .name string.
+        for prog in self.ProgramDict.values():
+            try:
+                p = prog.name
+            except:
+                raise AttributeError("Program classes must have a name.")
+            else:
+                assert isinstance(p, str), "Program class name is not a string."
+        
+        # Make sure all commands that are tied to a class have a .name string.
+        for com in self.commandDict.values():
+            if com!= None:
+                try:
+                    c = com.name
+                except:
+                    raise AttributeError("Command classes must have a name.")
+                else:
+                    assert isinstance(c, str), "Command class name is not a string."
 
+                    # Should there be optional aliases, they must also be a string.
+                    try:
+                        aliases = c.aliases
+                    except:
+                        continue
+                    else:
+                        assert all(isinstance(a, str) for a in aliases), "Command alias is not a string."
+
+        try:
+            # Associates [class].name and [class].aliases with the program or command class in a namespace.
+
+            # Program classes have names.
+            for prog in self.ProgramDict.values():
+                addToNameSpace(self.programNameSpace, prog.name, prog)
+
+            # Command classes have names, and maybe aliases.
+            for com in self.commandDict.values():
+                if com != None:
+                    addToNameSpace(self.commandNameSpace, com.name, com)
+                    try:
+                        for a in com.aliases:
+                            addToNameSpace(self.commandNameSpace, a, com)
+                    except:
+                        continue
+
+        except Exception as e:
+            raise Exception(f"An unexpected error occured with ListAll.findCommand(): {e}")
+        
         self.operation = self.ListAll
 
         super().__init__()
     
     def ListAll(self) -> print:
             try:
-                if self.programMap:
+                if self.ProgramDict:
                     print("Available programs:")
-                    for i in self.programMap.keys():
-                        print(f" {str(i)}: {self.programMap[i].name}")
+                    for i in self.ProgramDict.keys():
+                        print(f" {str(i)}: {self.ProgramDict[i].name}")
+
+                if self.ProgramDict and self.commandDict:
                     print()
-                if self.commandMap:
+
+                if self.commandDict:
                     print("Available commands:")
-                    for i in self.commandMap.keys():
-                        print(f" {self.commandMap[i].name}")
+                    for i in self.commandDict.keys():
+                        print(f" {str(i)}")
             except Exception as e:
                 raise Exception(f"An unexpected error occurred with \"ListAll\": {e}")
+
+    def findProgram(self, searchStr: str) -> classmethod | None:
+        try:
+            if searchStr in self.ProgramDict:
+                return self.ProgramDict[searchStr]
+            elif searchStr in self.programNameSpace:
+                return self.programNameSpace[searchStr]
+            else:
+                return None
+        except Exception as e:
+            raise Exception(f"An unexpected error occurred with ListAll.findProgram(): {e}")
+        
+    def findCommand(self, searchStr: str) -> classmethod | None:
+        try:
+            if searchStr in self.commandDict:
+                return self.commandDict[searchStr]
+            elif searchStr in self.commandNameSpace:
+                return self.commandNameSpace[searchStr]
+            else:
+                return None
+        except Exception as e:
+            raise Exception(f"An unexpected error occured with ListAll.findCommand(): {e}")
+    
+    def getHelp(self, searchStr: str) -> print:
+        if (prog := self.findProgram(searchStr)) != None:
+            prog.help()
+            
+        elif (com := self.findCommand(searchStr)) != None:
+            com.help()
+
+        elif searchStr in ["help", "info"]:
+            print("Runs a program or command's inherited .help() method to print out the associated class's doc string.",
+            "\n\nType \"help\" preceeded by a command, program, or progam number to instantly print its help info.",
+            "\nEx:",
+            "\n>>> help clear",
+            "\nClears the terminal. Works on posix and nt-like systems.")
+
+        elif searchStr in ["quit", "exit"]:
+            print("Exits the terminal.")
+
+        else:
+            return None

--- a/mycommands/mycommands.py
+++ b/mycommands/mycommands.py
@@ -34,7 +34,7 @@ class ClearTerminal(MyCommand):
     def ClearTerminal(self):
         try:
             if self.getos_name() == "nt":
-                self.run("cls")
+                self.run('cls', shell = True)
             else:
                 self.run("clear")
         except Exception as e:
@@ -71,7 +71,7 @@ class ListAll(MyCommand):
         self.programNameSpace = {}
         self.commandNameSpace = {}
 
-        def addToNameSpace(d: dict, name: str, inputtedClass = classmethod):
+        def addToNameSpace(d: dict, name: str, inputtedClass: classmethod):
             d[name.lower()] = inputtedClass
 
         try:

--- a/mycommands/mycommands.py
+++ b/mycommands/mycommands.py
@@ -188,4 +188,4 @@ class ListAll(MyCommand):
             print("Exits the terminal.")
 
         else:
-            return None
+            print("Command or program not found.")

--- a/mycommands/mycommands.py
+++ b/mycommands/mycommands.py
@@ -187,7 +187,7 @@ class ListAll(MyCommand):
 
         elif searchStr in ["help", "info"]:
             print("Runs a program or command's inherited .help() method to print out the associated class's doc string.",
-            "\n\nType \"help\" preceeded by a command, program, or progam number to instantly print its help info.",
+            "\n\nType \"help\" followed by a command, program, or progam number to instantly print its help info.",
             "\nEx:",
             "\n>>> help clear",
             "\nClears the terminal. Works on posix and nt-like systems.")

--- a/myprograms/myprograms.py
+++ b/myprograms/myprograms.py
@@ -1,8 +1,3 @@
-from sys import set_int_max_str_digits
-
-#Lets inputted numbers be longer than 4300 digits.
-set_int_max_str_digits(0)
-
 class myProgram:
     """Program object."""
     def __init__(self):

--- a/myprograms/myprograms.py
+++ b/myprograms/myprograms.py
@@ -3,12 +3,11 @@ class myProgram:
     def __init__(self):
         self.manual = self.__doc__
     
-    def help(self) -> list[str]:
+    def help(self) -> print:
         try:
-            for line in self.manual:
-                print(line)
+            print(self.manual)
         except Exception as e:
-            raise Exception(f"An unexpected error with printing help info: {e}")
+            raise Exception(f"An unexpected error occurred with printing help info: {e}")
 
 
 
@@ -18,9 +17,9 @@ class BinaryMaskToDecimalProgram(myProgram):
     When given a string of binary values, outputs the decimal integer that would be represented in Python after demasking.
     
     The first bit in the string of binary values denotes the sign (0 is positive, 1 is negative)."""
-    def __init__(self):
-        self.name = "BinaryMaskToDecimal"
+    name = "BinaryMaskToDecimal"
 
+    def __init__(self):
         self.prompt = "Enter a binary integer, prefaced with a signing bit (0 is positive): "
 
         self.operation = self.BinaryMaskToDecimal
@@ -67,9 +66,9 @@ class DecimalToBinaryMaskProgram(myProgram):
     When given a decimal integer, outputs the string of binary values that would be represented in Python after masking up towards the nearest 2^x bytes (1 byte, 2 bytes, 4 bytes, etc).
     
     The first bit denotes the sign (0 is positive, 1 is negative)."""
-    def __init__(self):
-        self.name = "DecimalToBinaryMask"
+    name = "DecimalToBinaryMask"
 
+    def __init__(self):
         self.prompt = "Enter a decimal integer: "
 
         self.operation = self.DecimalToBinaryMask

--- a/myprograms/myprograms.py
+++ b/myprograms/myprograms.py
@@ -1,3 +1,8 @@
+from sys import set_int_max_str_digits
+
+#Lets inputted numbers be longer than 4300 digits.
+set_int_max_str_digits(0)
+
 class myProgram:
     """Program object."""
     def __init__(self):
@@ -20,7 +25,7 @@ class BinaryMaskToDecimalProgram(myProgram):
     name = "BinaryMaskToDecimal"
 
     def __init__(self):
-        self.prompt = "Enter a binary integer, prefaced with a signing bit (0 is positive): "
+        self.prompt = "Enter a binary integer, prefaced with a signing bit (0 is positive):\n>>> "
 
         self.operation = self.BinaryMaskToDecimal
 
@@ -69,7 +74,7 @@ class DecimalToBinaryMaskProgram(myProgram):
     name = "DecimalToBinaryMask"
 
     def __init__(self):
-        self.prompt = "Enter a decimal integer: "
+        self.prompt = "Enter a decimal integer:\n>>> "
 
         self.operation = self.DecimalToBinaryMask
 

--- a/myshell.py
+++ b/myshell.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3.13
+import sys
 
 from mycommands import mycommands
 from myprograms import myprograms
 from myutils import myutils
 
-from sys import set_int_max_str_digits
-
 #Lets inputted numbers be longer than 4300 digits.
-set_int_max_str_digits(0)
+sys.set_int_max_str_digits(0)
 
 
 programDictionary = {
@@ -69,7 +68,7 @@ while (userInput := input("\nType a command, program, or program number:\n>>> ")
             case _:
                 program = ListAllCommand.findProgram(inputList[0])
 
-                if program != None:
+                if program:
                     programArgument = input(program.prompt)
                     print()
                     print(program.operation(programArgument))

--- a/myshell.py
+++ b/myshell.py
@@ -4,6 +4,11 @@ from mycommands import mycommands
 from myprograms import myprograms
 from myutils import myutils
 
+from sys import set_int_max_str_digits
+
+#Lets inputted numbers be longer than 4300 digits.
+set_int_max_str_digits(0)
+
 
 programDictionary = {
     "1": myprograms.BinaryMaskToDecimalProgram(),
@@ -36,13 +41,16 @@ except Exception as e:
 while (userInput := input("\nType a command, program, or program number:\n>>> ")) not in {"quit", "exit"}:
     try:
         userInput = userInput.lower()
+        inputList = myutils.Tokenizer(userInput)
         PageBreakCommand.operation()
         print()
 
-        match userInput:    
-            case "help" | "info":
-                helpInput = input("With what command or program?:\n>>> ")
-                print()
+        if len(inputList) == 0:
+            continue
+
+        match inputList[0]:    
+            case "help" | "info" | "h" | "i":
+                helpInput = myutils.Helper(inputList)
                 ListAllCommand.getHelp(helpInput.lower())
 
             
@@ -55,15 +63,11 @@ while (userInput := input("\nType a command, program, or program number:\n>>> ")
             case "clear" | "cls":
                 ClearTerminalCommand.operation()
 
+            case "quit" | "exit":
+                raise SystemExit
+
             case _:
-
-                if userInput.startswith(prefix := ("help ", "h ")):
-                    userInput = userInput.removeprefix("help ")
-                    # Not yet implemented
-                    continue
-
-
-                program = ListAllCommand.findProgram(userInput)
+                program = ListAllCommand.findProgram(inputList[0])
 
                 if program != None:
                     programArgument = input(program.prompt)

--- a/myshell.py
+++ b/myshell.py
@@ -41,7 +41,7 @@ while (userInput := input("\nType a command, program, or program number:\n>>> ")
 
         match userInput:    
             case "help" | "info":
-                helpInput = input("With what command or program?: ")
+                helpInput = input("With what command or program?:\n>>> ")
                 print()
                 ListAllCommand.getHelp(helpInput.lower())
 

--- a/myshell.py
+++ b/myshell.py
@@ -11,8 +11,10 @@ programDictionary = {
 }
 
 commandDictionary = {
-    "list": mycommands.ListAll({},{}),
-    "clear": mycommands.ClearTerminal()
+    "ListAll": mycommands.ListAll(),
+    "clear": mycommands.ClearTerminal(),
+    "help": None,
+    "exit": None
 }
 
 
@@ -31,7 +33,7 @@ except Exception as e:
 
 
 
-while (userInput := input("\n" + "Type a command or program number: ")) not in {"quit", "exit"}:
+while (userInput := input("\nType a command, program, or program number:\n>>> ")) not in {"quit", "exit"}:
     try:
         userInput = userInput.lower()
         PageBreakCommand.operation()
@@ -39,29 +41,40 @@ while (userInput := input("\n" + "Type a command or program number: ")) not in {
 
         match userInput:    
             case "help" | "info":
+                helpInput = input("With what command or program?: ")
                 print()
+                ListAllCommand.getHelp(helpInput.lower())
 
-                #prompt a command or program number, uses .help()
             
             case "list" | "ls" | "list all" | "list" | "listall":
                 ClearTerminalCommand.operation()
                 ListAllCommand.operation()
                 PageBreakCommand.operation()
+                continue
 
             case "clear" | "cls":
                 ClearTerminalCommand.operation()
 
             case _:
-                try:
-                    if userInput not in programDictionary:
-                        print("Not a command nor program.")
-                        continue
 
-                except ValueError:
-                    print("Unexpected error.")
+                if userInput.startswith(prefix := ("help ", "h ")):
+                    userInput = userInput.removeprefix("help ")
+                    # Not yet implemented
+                    continue
 
-                programArgument = input(programDictionary[userInput].prompt)
-                print(programDictionary[userInput].operation(programArgument))
 
+                program = ListAllCommand.findProgram(userInput)
+
+                if program != None:
+                    programArgument = input(program.prompt)
+                    print()
+                    print(program.operation(programArgument))
+                else:
+                    print("Not a command nor program.")
+            
+                
+
+                
+        PageBreakCommand.operation()
     except Exception as e:
         myutils.Error(e)

--- a/myutils/myutils.py
+++ b/myutils/myutils.py
@@ -10,9 +10,7 @@ class Error:
     
     .print(): Prints all stored Exceptions."""
     def __init__(self, *args: Exception):
-        for arg in args:
-            if not isinstance(arg, Exception):
-                raise ValueError("Cannot store Non-Exception object.")
+        assert all(isinstance(arg, Exception) for arg in args), "Cannot store Non-Exception object."
             
         self.storedExceptions = []
         self.operation = self.print
@@ -38,22 +36,66 @@ class OutputExtractor:
     
     For situations when the output needs to be comparable or hidden, such as during unit testing."""
     def __init__(self, givenClass: classmethod):
-        if hasattr(givenClass, 'operation') is False:
-            raise AttributeError("Given object has no .operation() method.")
+        assert hasattr(givenClass, 'operation'), "Given object has no .operation() method."
         
         self.storedClass = givenClass
         self.operation = self.storedClass.operation
     
-    def getOutput(self) -> str:
+    def getOutput(self, methodStr: str = None, *methodStrArgs) -> str:
+        """Defaults to running the .operation method of the stored class.
+        
+        If given the name of a different method, will attempt to run that method instead, with any passed arguments."""
         try:
             # Create StringIO object.
             redirected = StringIO()
 
             # Capture the method output.
             with redirect_stdout(redirected):
-                self.storedClass.operation()
+                if methodStr == None:
+                    self.storedClass.operation()
+                else:
+                    getattr(self.storedClass, methodStr)(*methodStrArgs)
 
             # Turn that IO object into a comparable string.
             return redirected.getvalue()
+        except AttributeError as e:
+            raise AttributeError(f"\"{type(self.storedClass).__name__}\" has no method \"{methodStr}\".")
         except Exception as e:
             raise Exception(f"An unexpected error occurred with the OutputExtractor output function: {e}")
+
+
+
+def Tokenizer(userInput: str) -> list[str]:
+    """Turns a string with spaces into a list of strings.
+    Removes empty words in case of superfluous spaces."""
+    assert isinstance(userInput, str), "Tokenizer can only accept a string as input."
+    try:
+        processed = userInput.split()
+        processed = list(filter(None, processed))
+        return processed
+    except Exception as e:
+        raise Exception(f"An unexpected error occurred with the input tokenizer: {e}")
+
+
+
+def Helper(inputList: list[str]) -> str:
+    """Manager for pulling help info.
+    If the inputList length is 1, asks for a particular name of a command or program.
+    If the length is 2, the second "word" must be the name of the command or program itself.
+    If the length is any longer, trims everything beyond the second "word", and runs itself with length 2."""
+    assert isinstance(inputList, list), "Helper can only accept a list of words as input."
+    assert all(isinstance(a, str) for a in inputList), "Helper can only accept a list of words as input."
+    try:
+        match len(inputList):
+            case 0:
+                return None
+            case 1:
+                helpInput = input("With what command or program?:\n>>> ")
+                print()
+                return helpInput
+            case 2:
+                return inputList[1].lower()
+            case _:
+                return Helper(inputList[:2])
+    except Exception as e:
+        raise Exception(f"An unexpected error occurred with the helper util: {e}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,10 @@
 __keyTests__ = ["test_outputextractor", "test_error"]
 
 __remainingTests__ = [
+            # myutils
+            "test_tokenizer",
+            "test_helper",
+
             # myprograms
             "test_binarymasktodecimalprogram",
             "test_decimaltobinarymaskprogram",

--- a/tests/test_clearterminal.py
+++ b/tests/test_clearterminal.py
@@ -14,9 +14,9 @@ class test_ClearTerminal(unittest.TestCase):
             return name
         return mocked
     
-    def unexpected(self, e):
-        print("An unexpected error occured while testing the ClearTerminal command:")
-        myutils.Error(e)
+    def unexpected(self, *args: Exception):
+        print("There was a problem with testing the ClearTerminal command.")
+        myutils.Error(*args)
         raise
 
     @patch("mycommands.ClearTerminal.getos_name",name_mock("nt"))

--- a/tests/test_clearterminal.py
+++ b/tests/test_clearterminal.py
@@ -27,8 +27,9 @@ class test_ClearTerminal(unittest.TestCase):
                 except* Exception as e:
                     self.unexpected(*e.exceptions)
                 else:
-                    subprocess.run.assert_called_once_with("cls")
+                    subprocess.run.assert_called_once_with("cls", shell = True)
 
+    @patch("mycommands.ClearTerminal.getos_name",name_mock("posix"))
     def test_clearTerminalOtherOS(self):
         with patch("mycommands.ClearTerminal.run") as subprocess.run:
             try:

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -87,7 +87,7 @@ class test_Error(unittest.TestCase):
         answerStr = "Cannot store Non-Exception object."
         
         try:
-            with self.assertRaises(ValueError) as e:
+            with self.assertRaises(AssertionError) as e:
                 self.createError("I am a silly cat")
         except* Exception as f:
             self.unexpected(*f.exceptions)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3.13
+
+import unittest
+
+from context import myutils
+
+
+class test_Helper(unittest.TestCase):
+    pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,12 +1,77 @@
 #!/usr/bin/env python3.13
 
 import unittest
+from unittest.mock import patch
+from io import StringIO
+from contextlib import redirect_stdout
 
 from context import myutils
 
 
 class test_Helper(unittest.TestCase):
-    pass
+
+    def unexpected(self, *args):
+        print("There was a problem with testing the Tokenizer util.")
+        myutils.Error(*args)
+        raise
+
+    # When Helper prompts "With what command or program?:\n>>> ", gives input "cat".
+    @patch('builtins.input', lambda *args: "cat")
+    def test_oneWordHelp(self):
+        answerStr = "cat"
+
+        try:
+            # Hides the new line printed after entering input.
+            with redirect_stdout(StringIO()):
+                outputStr = myutils.Helper(["help"])
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, answerStr)
+
+    def test_twoWordHelp(self):
+        answerStr = "cat"
+
+        try:
+            outputStr = myutils.Helper(["Help", "cat"])
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, answerStr)
+    
+    def test_threeOrMoreWordHelp(self):
+        answerStr = "cat"
+
+        try:
+            outputStr = myutils.Helper(["Help", "cat", "how", "about", "that"])
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, answerStr)
+
+    def test_error_notList(self):
+        answerStr = "Helper can only accept a list of words as input."
+
+        try:
+            with self.assertRaises(AssertionError) as e:
+                myutils.Helper(Exception("I am a cat"))
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, answerStr)
+
+    def test_error_notListOfWords(self):
+        answerStr = "Helper can only accept a list of words as input."
+
+        try:
+            with self.assertRaises(AssertionError) as e:
+                myutils.Helper(["my", "cat", "is", 5])
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, answerStr)
 
 
 if __name__ == '__main__':

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -8,6 +8,7 @@ from contextlib import redirect_stdout
 from context import myutils
 
 
+
 class test_Helper(unittest.TestCase):
 
     def unexpected(self, *args):
@@ -72,6 +73,7 @@ class test_Helper(unittest.TestCase):
         else:
             outputStr = str(e.exception)
             self.assertEqual(outputStr, answerStr)
+
 
 
 if __name__ == '__main__':

--- a/tests/test_listall.py
+++ b/tests/test_listall.py
@@ -208,7 +208,7 @@ class test_ListAll(unittest.TestCase):
     def test_getHelpWithHelp(self):
         helpAnswer = """Runs a program or command's inherited .help() method to print out the associated class's doc string. 
 
-Type "help" preceeded by a command, program, or progam number to instantly print its help info. 
+Type "help" followed by a command, program, or progam number to instantly print its help info. 
 Ex: 
 >>> help clear 
 Clears the terminal. Works on posix and nt-like systems.\n"""

--- a/tests/test_listall.py
+++ b/tests/test_listall.py
@@ -13,15 +13,19 @@ class test_ListAll(unittest.TestCase):
     commandDict = {
             "clear": mycommands.ClearTerminal()
         }
-    programAnswer = "Available programs:\n 1: BinaryMaskToDecimal\n\n"
+    programAnswer = "Available programs:\n 1: BinaryMaskToDecimal\n"
     commandAnswer = "Available commands:\n clear\n"
-    comboAnswer = programAnswer + commandAnswer
+    comboAnswer = programAnswer + "\n" + commandAnswer
 
     class TestProgram():
         name = "TestProgram"
     
     class TestCommand():
         name = "TestCommand"
+
+    class TestCommandWithAliases():
+        name = "TestCommand2"
+        aliases = ["secondtest"]
 
     def createListAll(self, program: map, command: map) -> str:
         try:
@@ -88,9 +92,9 @@ class test_ListAll(unittest.TestCase):
             self.evaluate(extractor, self.commandAnswer)
 
     def test_altDicts(self):
-        testProgramDict = {"test": self.TestProgram()}
-        testCommandDict = {"test2": self.TestCommand()}
-        testAnswer = "Available programs:\n test: TestProgram\n\nAvailable commands:\n TestCommand\n"
+        testProgramDict = {"1": self.TestProgram()}
+        testCommandDict = {"command": self.TestCommand(), "empty": None}
+        testAnswer = "Available programs:\n 1: TestProgram\n\nAvailable commands:\n command\n empty\n"
 
         try:
             testList = self.createListAll(testProgramDict, testCommandDict)
@@ -100,7 +104,34 @@ class test_ListAll(unittest.TestCase):
         else:
             self.evaluate(extractor, testAnswer)
 
-    def test_error_valueError(self):
+    def test_findProgram(self):
+        pass
+
+    def test_findProgramNonexistent(self):
+        pass
+
+    def test_findCommand(self):
+        pass
+
+    def test_findProgramNonexistent(self):
+        pass
+
+    def test_getHelpWithProgram(self):
+        pass
+
+    def test_getHelpWithCommand(self):
+        pass
+
+    def test_getHelpWithHelp(self):
+        pass
+
+    def test_getHelpWithQuit(self):
+        pass
+
+    def test_getHelpNonexistent(self):
+        pass
+
+    def test_error_nonDict(self):
         answerStr = "ListAll only accepts dict objects."
         
         try:
@@ -112,7 +143,20 @@ class test_ListAll(unittest.TestCase):
             outputStr = str(e.exception)
             self.assertEqual(outputStr, answerStr)
 
+    def test_error_CommandClassHasNoName(self):
+        pass
 
+    def test_error_ProgramClassHasNoName(self):
+        pass
+
+    def test_error_CommandNameNotStr(self):
+        pass
+
+    def test_error_ProgramNameNotStr(self):
+        pass
+
+    def test_error_ProgramAliasNotStr(self):
+        pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_listall.py
+++ b/tests/test_listall.py
@@ -113,7 +113,7 @@ class test_ListAll(unittest.TestCase):
     def test_findCommand(self):
         pass
 
-    def test_findProgramNonexistent(self):
+    def test_findCommandNonexistent(self):
         pass
 
     def test_getHelpWithProgram(self):

--- a/tests/test_listall.py
+++ b/tests/test_listall.py
@@ -20,12 +20,32 @@ class test_ListAll(unittest.TestCase):
     class TestProgram():
         name = "TestProgram"
     
+    class TestProgramNameless():
+        pass
+
+    class TestProgramWeirdName():
+        name = ["I", "am", "a", "silly", "cat"]
+
     class TestCommand():
         name = "TestCommand"
+
+    class TestCommandNameless():
+        pass
+
+    class TestCommandWeirdName():
+        name = Exception("I am a silly cat.")
 
     class TestCommandWithAliases():
         name = "TestCommand2"
         aliases = ["secondtest"]
+
+    class TestCommandWeirdAliases():
+        name = "TestCommandWeirdAliases"
+        aliases = {"I am" : Exception("A silly cat")}
+    
+    class TestCommandWeirdAliasesString():
+        name = "TestCommandWeirdAliasesString"
+        aliases = ["I am a silly cat", 4]
 
     def createListAll(self, program: map, command: map) -> str:
         try:
@@ -51,7 +71,7 @@ class test_ListAll(unittest.TestCase):
             self.assertEqual(self.outputStr, answer)
 
     def unexpected(self, *args: Exception) -> print:
-        print("There was a problem with testing the listall command.")
+        print("There was a problem with testing the ListAll command.")
         myutils.Error(*args)
         raise
 
@@ -75,7 +95,7 @@ class test_ListAll(unittest.TestCase):
     
     def test_onlyPrograms(self):
         try:
-            testList = self.createListAll(self.programDict, {})
+            testList = mycommands.ListAll(programDict = self.programDict)
             extractor = self.createExtractor(testList)
         except* Exception as e:
             self.unexpected(*e.exceptions)
@@ -84,7 +104,7 @@ class test_ListAll(unittest.TestCase):
     
     def test_onlyCommands(self):
         try:
-            testList = self.createListAll({}, self.commandDict)
+            testList = mycommands.ListAll(commandDict = self.commandDict)
             extractor = self.createExtractor(testList)
         except* Exception as e:
             self.unexpected(*e.exceptions)
@@ -105,37 +125,130 @@ class test_ListAll(unittest.TestCase):
             self.evaluate(extractor, testAnswer)
 
     def test_findProgram(self):
-        pass
+        try:
+            testList = self.createListAll(self.programDict, {})
+            program = testList.findProgram("BinaryMaskToDecimal")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(type(myprograms.BinaryMaskToDecimalProgram()), type(program))
 
     def test_findProgramNonexistent(self):
-        pass
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            program = testList.findProgram("meow")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(program, None)
 
-    def test_findCommand(self):
-        pass
+    def test_findCommandByName(self):
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            command = testList.findCommand("Clear")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(type(mycommands.ClearTerminal()), type(command))
+
+    def test_findCommandByAlias(self):
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            command = testList.findCommand("cls")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(type(mycommands.ClearTerminal()), type(command))
 
     def test_findCommandNonexistent(self):
-        pass
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            command = testList.findCommand("silly cat")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(command, None)
 
     def test_getHelpWithProgram(self):
-        pass
+        helpAnswer = myprograms.BinaryMaskToDecimalProgram.__doc__ + "\n"
+        
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            extractor = self.createExtractor(testList)
+            outputStr = extractor.getOutput("getHelp", "BinaryMaskToDecimal")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, helpAnswer)
+        
+    def test_getHelpWithCommandByName(self):
+        helpAnswer = mycommands.ClearTerminal.__doc__ + "\n"
+        
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            extractor = self.createExtractor(testList)
+            outputStr = extractor.getOutput("getHelp", "clear")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, helpAnswer)
 
-    def test_getHelpWithCommand(self):
-        pass
+    def test_getHelpWithCommandByAlias(self):
+        helpAnswer = mycommands.ClearTerminal.__doc__ + "\n"
+        
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            extractor = self.createExtractor(testList)
+            outputStr = extractor.getOutput("getHelp", "cls")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, helpAnswer)
 
     def test_getHelpWithHelp(self):
-        pass
+        helpAnswer = """Runs a program or command's inherited .help() method to print out the associated class's doc string. 
+
+Type "help" preceeded by a command, program, or progam number to instantly print its help info. 
+Ex: 
+>>> help clear 
+Clears the terminal. Works on posix and nt-like systems.\n"""
+        
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            extractor = self.createExtractor(testList)
+            outputStr = extractor.getOutput("getHelp", "help")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, helpAnswer)
 
     def test_getHelpWithQuit(self):
-        pass
+        helpAnswer = "Exits the terminal.\n"
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            extractor = self.createExtractor(testList)
+            outputStr = extractor.getOutput("getHelp", "quit")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, helpAnswer)
 
     def test_getHelpNonexistent(self):
-        pass
+        helpAnswer = "Command or program not found.\n"
+        try:
+            testList = self.createListAll(self.programDict, self.commandDict)
+            extractor = self.createExtractor(testList)
+            outputStr = extractor.getOutput("getHelp", "silly cat")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputStr, helpAnswer)
 
     def test_error_nonDict(self):
         answerStr = "ListAll only accepts dict objects."
         
         try:
-            with self.assertRaises(ValueError) as e:
+            with self.assertRaises(TypeError) as e:
                 self.createListAll(4, 5)
         except* Exception as f:
             self.unexpected(*f.exceptions)
@@ -144,19 +257,104 @@ class test_ListAll(unittest.TestCase):
             self.assertEqual(outputStr, answerStr)
 
     def test_error_CommandClassHasNoName(self):
-        pass
+        testProgramDict = {"1": self.TestProgram()}
+        testCommandDict = {"command": self.TestCommandNameless(), "empty": None}
+        testAnswer = "Command classes must have a name."
+
+        try:
+            with self.assertRaises(AttributeError) as e:
+                self.createListAll(testProgramDict, testCommandDict)
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, testAnswer)
 
     def test_error_ProgramClassHasNoName(self):
-        pass
+        testProgramDict = {"1": self.TestProgramNameless()}
+        testCommandDict = {"command": self.TestCommand(), "empty": None}
+        testAnswer = "Program classes must have a name."
+
+        try:
+            with self.assertRaises(AttributeError) as e:
+                self.createListAll(testProgramDict, testCommandDict)
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, testAnswer)
 
     def test_error_CommandNameNotStr(self):
-        pass
+        testProgramDict = {"1": self.TestProgram()}
+        testCommandDict = {"command": self.TestCommandWeirdName(), "empty": None}
+        testAnswer = "Command class name is not a string."
+
+        try:
+            with self.assertRaises(AssertionError) as e:
+                self.createListAll(testProgramDict, testCommandDict)
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, testAnswer)
 
     def test_error_ProgramNameNotStr(self):
-        pass
+        testProgramDict = {"1": self.TestProgramWeirdName()}
+        testCommandDict = {"command": self.TestCommand(), "empty": None}
+        testAnswer = "Program class name is not a string."
 
-    def test_error_ProgramAliasNotStr(self):
-        pass
+        try:
+            with self.assertRaises(AssertionError) as e:
+                self.createListAll(testProgramDict, testCommandDict)
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, testAnswer)
+
+    def test_error_CommandAliasNotList(self):
+        testProgramDict = {"1": self.TestProgram()}
+        testCommandDict = {"command": self.TestCommandWeirdAliases(), "empty": None}
+        testAnswer = "Command aliases is not a list."
+
+        try:
+            with self.assertRaises(AssertionError) as e:
+                self.createListAll(testProgramDict, testCommandDict)
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, testAnswer)
+
+    def test_error_CommandAliasNotString(self):
+        testProgramDict = {"1": self.TestProgram()}
+        testCommandDict = {"command": self.TestCommandWeirdAliasesString(), "empty": None}
+        testAnswer = "Command alias is not a string."
+
+        try:
+            with self.assertRaises(AssertionError) as e:
+                self.createListAll(testProgramDict, testCommandDict)
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, testAnswer)
+
+    def test_eror_duplicateKey(self):
+        testProgramDict = {"1": self.TestProgram(), "2": self.TestProgram}
+        testCommandDict = {"command": self.TestCommand(), "empty": None}
+        testAnswer = "Duplicate name or alias: \"testprogram\" already in dictionary."
+
+        try:
+            with self.assertRaises(ValueError) as e:
+                self.createListAll(testProgramDict, testCommandDict)
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, testAnswer)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_outputextractor.py
+++ b/tests/test_outputextractor.py
@@ -5,11 +5,21 @@ import unittest
 from context import myutils
 
 
+
 class test_OutputExtractor(unittest.TestCase):
     "Tests the OutputExtractor util."
     class SillyFunction():
         def operation(self):
             print("Meow!")
+        
+        def whoAmI(self):
+            print("I am a silly cat.")
+
+        def printColor(self, color: str):
+            print(f"My color is {color}.")
+
+        def countUp(self, num: int):
+            print(num + 1)
 
     class OperationlessFunction():
         pass
@@ -30,6 +40,29 @@ class test_OutputExtractor(unittest.TestCase):
         else:
             self.assertEqual(answerStr, extractor.getOutput())
 
+    def test_otherMethod(self):
+        answerStr = "I am a silly cat.\n"
+
+        try:
+            silly = self.SillyFunction()
+            extractor = myutils.OutputExtractor(silly)
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            extractor.getOutput("whoAmI")
+            self.assertEqual(answerStr, extractor.getOutput("whoAmI"))
+
+    def test_otherMethodWithArgs(self):
+        answerStr = "My color is orange.\n"
+
+        try:
+            silly = self.SillyFunction()
+            extractor = myutils.OutputExtractor(silly)
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(answerStr, extractor.getOutput("printColor", "orange"))           
+
     def test_recursion(self):
         answerStr = "Meow!\n"
         
@@ -48,7 +81,7 @@ class test_OutputExtractor(unittest.TestCase):
         answerStr = "Given object has no .operation() method."
         
         try:
-            with self.assertRaises(AttributeError) as e:
+            with self.assertRaises(AssertionError) as e:
                 myutils.OutputExtractor(self.OperationlessFunction)
         except* Exception as f:
             self.unexpected(*f.exceptions)
@@ -56,7 +89,46 @@ class test_OutputExtractor(unittest.TestCase):
             outputStr = str(e.exception)
             self.assertEqual(outputStr, answerStr)
 
+    def test_error_doesNotHaveFunction(self):
+        answerStr = "\"SillyFunction\" has no method \"notafunction\"."
+        try:
+            with self.assertRaises(Exception) as e:
+                silly = self.SillyFunction()
+                extractor = myutils.OutputExtractor(silly)
+                extractor.getOutput("notafunction")
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, answerStr)
 
+    def test_error_functionIssueWithArguments(self):
+        answerStr = "An unexpected error occurred with the OutputExtractor output function: test_OutputExtractor.SillyFunction.whoAmI() takes 1 positional argument but 3 were given"
+
+        try:
+            with self.assertRaises(Exception) as e:
+                silly = self.SillyFunction()
+                extractor = myutils.OutputExtractor(silly)
+                extractor.getOutput("whoAmI", "kitty", "cat")
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, answerStr)
+
+    def test_error_functionIssueInternal(self):
+        answerStr = "An unexpected error occurred with the OutputExtractor output function: unsupported operand type(s) for +: 'Exception' and 'int'"
+
+        try:
+            with self.assertRaises(Exception) as e:
+                silly = self.SillyFunction()
+                extractor = myutils.OutputExtractor(silly)
+                extractor.getOutput("countUp", Exception(4))
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, answerStr)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3.13
+
+import unittest
+
+from context import myutils
+
+
+
+class test_Tokenizer(unittest.TestCase):
+    def unexpected(self, *args):
+        print("There was a problem with testing the Tokenizer util.")
+        myutils.Error(*args)
+        raise
+    
+    def test_emptyString(self):
+        answerList = []
+
+        try:
+            outputList = myutils.Tokenizer("")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputList,answerList)
+
+    def test_emptyStringWithSpaces(self):
+        answerList = []
+
+        try:
+            outputList = myutils.Tokenizer("    ")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputList,answerList)           
+    
+    def test_oneWordString(self):
+        answerList = ["cat"]
+
+        try:
+            outputList = myutils.Tokenizer("cat")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputList, answerList)
+
+    def test_oneWordStringWithSpaces(self):
+        answerList = ["cat"]
+
+        try:
+            outputList = myutils.Tokenizer("    cat        ")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputList, answerList)
+
+    def test_twoWordString(self):
+        answerList = ["silly","cat"]
+
+        try:
+            outputList = myutils.Tokenizer("silly cat")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputList, answerList)
+
+    def test_twoWordStringWithManySpaces(self):
+        answerList = ["silly","cat"]
+
+        try:
+            outputList = myutils.Tokenizer(" silly      cat   ")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputList, answerList)
+
+    def test_threeWordString(self):
+        answerList = ["my","silly","cat"]
+
+        try:
+            outputList = myutils.Tokenizer("my silly cat")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputList, answerList)
+
+    def test_threeWordStringWithManySpaces(self):
+        answerList = ["my","silly","cat"]
+
+        try:
+            outputList = myutils.Tokenizer("  my    silly  cat    ")
+        except* Exception as e:
+            self.unexpected(*e.exceptions)
+        else:
+            self.assertEqual(outputList, answerList)
+
+    def test_Error_TypeError(self):
+        answerStr = "Tokenizer can only accept a string as input."
+
+        try:
+            with self.assertRaises(AssertionError) as e:
+                myutils.Tokenizer(Exception("I am a silly cat"))
+        except* Exception as f:
+            self.unexpected(*f.exceptions)
+        else:
+            outputStr = str(e.exception)
+            self.assertEqual(outputStr, answerStr)  
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### New Stuff
- Commands and programs now have names (and maybe aliases)! In the shell, programs can be run by name.
- Names are outside of programs and commands' __init__ methods, so they don't need to be initialized to be called.
- Names and aliases get added to namespaces in ListAll.
- ListAll's getProgram and GetProgram work with the namespaces to facilitate running programs by name in shell.
- The shell handles userinput as "words". This is helped by the new Tokenizer util.
- The above makes "help" robust! the new Helper util asists ListAll with either prompting for a program or command when you just input `help` or just goes ahead and prints the help if you use `help [command or program]`.

### Existing Stuff
- myshell can now handle however long of input your terminal will allow. Now you can convert numbers or masks longer than the default limit of 4300 characters.
- ListAll got heavily overhauled to properly manage namespaces. Lots of new unit tests too.
- ClearTerminal works properly on Windows. shell=True is okay for terminal commands.
- Terminal input is now `>>> ` because that's pretty 👉👈.
- OutputExtractor can now catch print output from more than just `.operation()`. Also gained unit tests.

![cat typing](https://github.com/user-attachments/assets/0a178b3a-0f8b-4fc8-aa40-00d32fafe3c9)